### PR TITLE
Fix focus

### DIFF
--- a/IMEPlugin/PluginUI.cs
+++ b/IMEPlugin/PluginUI.cs
@@ -43,7 +43,7 @@ namespace IMEPlugin
             }
 
             ImGui.SetNextWindowSize(new Vector2(100, 200), ImGuiCond.FirstUseEver);
-            if (ImGui.Begin("IME Plugin", ref this.visible, ImGuiWindowFlags.NoTitleBar))
+            if (ImGui.Begin("IME Plugin", ref this.visible, ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoFocusOnAppearing))
             {
                 ImGui.Text(_plugin.ImmComp);
                 ImGui.Separator();


### PR DESCRIPTION
有些窗口(比如QoL Bar的按钮配置)会因为IME面板弹出而失去焦点自动关闭
加了个flag让IME面板创建时不转移焦点